### PR TITLE
TST: Use flake8 config in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,9 @@ show-response = 1
 minversion = 2.2
 norecursedirs = build docs/_build relic
 
+[flake8]
+# See http://flake8.pycqa.org/en/latest/user/configuration.html
+
 [entry_points]
 
 [bdist_wheel]


### PR DESCRIPTION
Since there is a test with `flake8` in `.travis.yml`, this is probably needed as well.