### PR TITLE
add allow_failure

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -19,6 +19,7 @@ jobs:
   ci_tests:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.allow_failure}}
     strategy:
       matrix:
         include:
@@ -26,41 +27,49 @@ jobs:
             os: ubuntu-latest
             python: 3.x
             toxenv: codestyle
+            allow_failure: false
 
           - name: PEP 517
             os: ubuntu-latest
             python: 3.x
             toxenv: pep517
+            allow_failure: false
 
           - name: Security audit
             os: ubuntu-latest
             python: 3.x
             toxenv: securityaudit
+            allow_failure: false
 
           - name: Python 3.7 with oldest supported dependencies
             os: ubuntu-latest
             python: 3.7
             toxenv: py37-test-oldestdeps
+            allow_failure: false
 
           - name: Python 3.9 with coverage checking
             os: ubuntu-latest
             python: 3.9
             toxenv: py39-test-cov
+            allow_failure: false
 
           - name: OS X - Python 3.8
             os: macos-latest
             python: 3.8
             toxenv: py38-test
+            allow_failure: false
 
           - name: Windows - Python 3.8
             os: windows-latest
             python: 3.8
             toxenv: py38-test
+            allow_failure: false
 
           - name: Python 3.9 with latest dev versions of key dependencies
             os: ubuntu-latest
             python: 3.9
             toxenv: py39-test-devdeps
+            allow_failure: false
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
This PR makes a small change inspired by spacetelescope/jdaviz#369 - there I had a build I wanted to be an "Allowed failure" a la the Travis option.  This PR does that using the [continue-on-error](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error) github action option