### PR TITLE
MNT: Stop using enable_deprecations_as_exceptions

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -10,10 +10,6 @@ try:
 except ImportError:
     version = 'unknown'
 
-# The following line treats all DeprecationWarnings as exceptions.
-from astropy.tests.helper import enable_deprecations_as_exceptions
-enable_deprecations_as_exceptions()
-
 # Uncomment and customize the following lines to add/remove entries
 # from the list of packages for which version numbers are displayed
 # when running the tests.


### PR DESCRIPTION
This pull request is to remove soon to be deprecated code; also see astropy/astropy#12633 .